### PR TITLE
Fix/add missing filters on search pages

### DIFF
--- a/gestaolegal/controllers/caso_controller.py
+++ b/gestaolegal/controllers/caso_controller.py
@@ -32,6 +32,7 @@ caso_controller = Blueprint("caso_api", __name__)
 @caso_controller.route("/", methods=["GET"])
 @authenticated
 def get():
+    current_user: UserInfo = RequestContext.get_current_user()
     page = request.args.get("page", default=1, type=int)
     per_page = request.args.get("per_page", default=10, type=int)
     search = request.args.get("search", default="", type=str)
@@ -41,6 +42,13 @@ def get():
     situacao_deferimento = request.args.get(
         "situacao_deferimento", default=None, type=str
     )
+    user = request.args.get("user", default=None, type=str)
+
+    id_usuario_responsavel = None
+    if user == "me":
+        id_usuario_responsavel = current_user.id
+    elif user is not None and user.isdigit():
+        id_usuario_responsavel = int(user)
 
     caso_service = CasoService()
     result = caso_service.search(
@@ -48,6 +56,7 @@ def get():
         search=search,
         show_inactive=show_inactive.value,
         situacao_deferimento=situacao_deferimento,
+        id_usuario_responsavel=id_usuario_responsavel,
     )
 
     return success_response(data=result.to_dict())

--- a/gestaolegal/controllers/caso_controller.py
+++ b/gestaolegal/controllers/caso_controller.py
@@ -44,11 +44,11 @@ def get():
     )
     user = request.args.get("user", default=None, type=str)
 
-    id_usuario_responsavel = None
+    responsible_user = None
     if user == "me":
-        id_usuario_responsavel = current_user.id
+        responsible_user = current_user.id
     elif user is not None and user.isdigit():
-        id_usuario_responsavel = int(user)
+        responsible_user = int(user)
 
     caso_service = CasoService()
     result = caso_service.search(
@@ -56,7 +56,7 @@ def get():
         search=search,
         show_inactive=show_inactive.value,
         situacao_deferimento=situacao_deferimento,
-        id_usuario_responsavel=id_usuario_responsavel,
+        responsible_user=responsible_user,
     )
 
     return success_response(data=result.to_dict())

--- a/gestaolegal/services/caso_service.py
+++ b/gestaolegal/services/caso_service.py
@@ -67,10 +67,10 @@ class CasoService:
         search: str = "",
         show_inactive: bool = False,
         situacao_deferimento: str | None = None,
-        id_usuario_responsavel: int | None = None,
+        responsible_user: int | None = None,
     ) -> PaginatedResult[Caso]:
         logger.info(
-            f"Searching casos with search: '{search}', situacao_deferimento: {situacao_deferimento}, id_usuario_responsavel: {id_usuario_responsavel}, show_inactive: {show_inactive}, page: {page_params['page']}, per_page: {page_params['per_page']}"
+            f"Searching casos with search: '{search}', situacao_deferimento: {situacao_deferimento}, responsible_user: {responsible_user}, show_inactive: {show_inactive}, page: {page_params['page']}, per_page: {page_params['per_page']}"
         )
         clauses: list[WhereClause | ComplexWhereClause] = []
 
@@ -86,12 +86,12 @@ class CasoService:
                 )
             )
 
-        if id_usuario_responsavel is not None:
+        if responsible_user is not None:
             clauses.append(
                 WhereClause(
                     column="id_usuario_responsavel",
                     operator="==",
-                    value=id_usuario_responsavel,
+                    value=responsible_user,
                 )
             )
 

--- a/gestaolegal/services/caso_service.py
+++ b/gestaolegal/services/caso_service.py
@@ -67,9 +67,10 @@ class CasoService:
         search: str = "",
         show_inactive: bool = False,
         situacao_deferimento: str | None = None,
+        id_usuario_responsavel: int | None = None,
     ) -> PaginatedResult[Caso]:
         logger.info(
-            f"Searching casos with search: '{search}', situacao_deferimento: {situacao_deferimento}, show_inactive: {show_inactive}, page: {page_params['page']}, per_page: {page_params['per_page']}"
+            f"Searching casos with search: '{search}', situacao_deferimento: {situacao_deferimento}, id_usuario_responsavel: {id_usuario_responsavel}, show_inactive: {show_inactive}, page: {page_params['page']}, per_page: {page_params['per_page']}"
         )
         clauses: list[WhereClause | ComplexWhereClause] = []
 
@@ -82,6 +83,15 @@ class CasoService:
                     column="situacao_deferimento",
                     operator="==",
                     value=situacao_deferimento,
+                )
+            )
+
+        if id_usuario_responsavel is not None:
+            clauses.append(
+                WhereClause(
+                    column="id_usuario_responsavel",
+                    operator="==",
+                    value=id_usuario_responsavel,
                 )
             )
 

--- a/tests/api/test_caso_api.py
+++ b/tests/api/test_caso_api.py
@@ -852,6 +852,242 @@ def test_upload_arquivo_without_file(
     assert response.status_code == 400
 
 
+def test_filter_casos_by_user_me(
+    client: FlaskClient,
+    auth_headers: dict[str, str],
+    non_admin_auth_headers: dict[str, str],
+    sample_caso_data: dict[str, Any],
+) -> None:
+    caso_admin_data = {
+        **sample_caso_data,
+        "area_direito": "penal",
+        "id_usuario_responsavel": 1,
+    }
+    admin_caso_response = client.post(
+        "/api/caso/", json=caso_admin_data, headers=auth_headers
+    )
+    assert admin_caso_response.status_code == 201
+    admin_caso = get_success_data(admin_caso_response)
+    assert admin_caso is not None
+    admin_caso_id = admin_caso["id"]
+
+    caso_non_admin_data = {
+        **sample_caso_data,
+        "area_direito": "civil",
+        "id_usuario_responsavel": 2,
+    }
+    non_admin_caso_response = client.post(
+        "/api/caso/", json=caso_non_admin_data, headers=non_admin_auth_headers
+    )
+    assert non_admin_caso_response.status_code == 201
+    non_admin_caso = get_success_data(non_admin_caso_response)
+    assert non_admin_caso is not None
+    non_admin_caso_id = non_admin_caso["id"]
+
+    response = client.get("/api/caso/?user=me", headers=auth_headers)
+
+    assert response.status_code == 200
+    data = get_success_data(response)
+    assert data is not None
+    items = data["items"]
+    assert isinstance(items, list)
+
+    caso_ids = [caso["id"] for caso in items]
+    assert admin_caso_id in caso_ids
+    assert non_admin_caso_id not in caso_ids
+
+
+def test_filter_casos_by_user_id(
+    client: FlaskClient,
+    auth_headers: dict[str, str],
+    non_admin_auth_headers: dict[str, str],
+    sample_caso_data: dict[str, Any],
+) -> None:
+    caso_admin_data = {
+        **sample_caso_data,
+        "area_direito": "trabalhista",
+        "id_usuario_responsavel": 1,
+    }
+    admin_caso_response = client.post(
+        "/api/caso/", json=caso_admin_data, headers=auth_headers
+    )
+    assert admin_caso_response.status_code == 201
+    admin_caso = get_success_data(admin_caso_response)
+    assert admin_caso is not None
+    admin_caso_id = admin_caso["id"]
+    admin_user_id = admin_caso["id_usuario_responsavel"]
+
+    caso_non_admin_data = {
+        **sample_caso_data,
+        "area_direito": "consumidor",
+        "id_usuario_responsavel": 2,
+    }
+    non_admin_caso_response = client.post(
+        "/api/caso/", json=caso_non_admin_data, headers=non_admin_auth_headers
+    )
+    assert non_admin_caso_response.status_code == 201
+    non_admin_caso = get_success_data(non_admin_caso_response)
+    assert non_admin_caso is not None
+    non_admin_caso_id = non_admin_caso["id"]
+    non_admin_caso["id_usuario_responsavel"]
+
+    response = client.get(f"/api/caso/?user={admin_user_id}", headers=auth_headers)
+
+    assert response.status_code == 200
+    data = get_success_data(response)
+    assert data is not None
+    items = data["items"]
+    assert isinstance(items, list)
+
+    caso_ids = [caso["id"] for caso in items]
+    assert admin_caso_id in caso_ids
+    assert non_admin_caso_id not in caso_ids
+
+    for caso in items:
+        assert caso["id_usuario_responsavel"] == admin_user_id
+
+
+def test_filter_casos_by_user_id_as_non_admin(
+    client: FlaskClient,
+    auth_headers: dict[str, str],
+    non_admin_auth_headers: dict[str, str],
+    sample_caso_data: dict[str, Any],
+) -> None:
+    caso_admin_data = {
+        **sample_caso_data,
+        "area_direito": "penal",
+        "id_usuario_responsavel": 1,
+    }
+    admin_caso_response = client.post(
+        "/api/caso/", json=caso_admin_data, headers=auth_headers
+    )
+    assert admin_caso_response.status_code == 201
+    admin_caso = get_success_data(admin_caso_response)
+    assert admin_caso is not None
+    admin_caso_id = admin_caso["id"]
+
+    caso_non_admin_data = {
+        **sample_caso_data,
+        "area_direito": "civil",
+        "id_usuario_responsavel": 2,
+    }
+    non_admin_caso_response = client.post(
+        "/api/caso/", json=caso_non_admin_data, headers=non_admin_auth_headers
+    )
+    assert non_admin_caso_response.status_code == 201
+    non_admin_caso = get_success_data(non_admin_caso_response)
+    assert non_admin_caso is not None
+    non_admin_caso_id = non_admin_caso["id"]
+    non_admin_user_id = non_admin_caso["id_usuario_responsavel"]
+
+    response = client.get(
+        f"/api/caso/?user={non_admin_user_id}", headers=non_admin_auth_headers
+    )
+
+    assert response.status_code == 200
+    data = get_success_data(response)
+    assert data is not None
+    items = data["items"]
+    assert isinstance(items, list)
+
+    caso_ids = [caso["id"] for caso in items]
+    assert non_admin_caso_id in caso_ids
+    assert admin_caso_id not in caso_ids
+
+    for caso in items:
+        assert caso["id_usuario_responsavel"] == non_admin_user_id
+
+
+def test_filter_casos_without_user_param_returns_all(
+    client: FlaskClient,
+    auth_headers: dict[str, str],
+    non_admin_auth_headers: dict[str, str],
+    sample_caso_data: dict[str, Any],
+) -> None:
+    caso_admin_data = {
+        **sample_caso_data,
+        "area_direito": "ambiental",
+        "id_usuario_responsavel": 1,
+    }
+    admin_caso_response = client.post(
+        "/api/caso/", json=caso_admin_data, headers=auth_headers
+    )
+    assert admin_caso_response.status_code == 201
+    admin_caso = get_success_data(admin_caso_response)
+    assert admin_caso is not None
+    admin_caso_id = admin_caso["id"]
+
+    caso_non_admin_data = {
+        **sample_caso_data,
+        "area_direito": "tributario",
+        "id_usuario_responsavel": 2,
+    }
+    non_admin_caso_response = client.post(
+        "/api/caso/", json=caso_non_admin_data, headers=non_admin_auth_headers
+    )
+    assert non_admin_caso_response.status_code == 201
+    non_admin_caso = get_success_data(non_admin_caso_response)
+    assert non_admin_caso is not None
+    non_admin_caso_id = non_admin_caso["id"]
+
+    response = client.get("/api/caso/", headers=auth_headers)
+
+    assert response.status_code == 200
+    data = get_success_data(response)
+    assert data is not None
+    items = data["items"]
+    assert isinstance(items, list)
+
+    caso_ids = [caso["id"] for caso in items]
+    assert admin_caso_id in caso_ids
+    assert non_admin_caso_id in caso_ids
+
+
+def test_filter_casos_by_invalid_user_param_returns_all(
+    client: FlaskClient,
+    auth_headers: dict[str, str],
+    non_admin_auth_headers: dict[str, str],
+    sample_caso_data: dict[str, Any],
+) -> None:
+    caso_admin_data = {
+        **sample_caso_data,
+        "area_direito": "familia",
+        "id_usuario_responsavel": 1,
+    }
+    admin_caso_response = client.post(
+        "/api/caso/", json=caso_admin_data, headers=auth_headers
+    )
+    assert admin_caso_response.status_code == 201
+    admin_caso = get_success_data(admin_caso_response)
+    assert admin_caso is not None
+    admin_caso_id = admin_caso["id"]
+
+    caso_non_admin_data = {
+        **sample_caso_data,
+        "area_direito": "previdenciario",
+        "id_usuario_responsavel": 2,
+    }
+    non_admin_caso_response = client.post(
+        "/api/caso/", json=caso_non_admin_data, headers=non_admin_auth_headers
+    )
+    assert non_admin_caso_response.status_code == 201
+    non_admin_caso = get_success_data(non_admin_caso_response)
+    assert non_admin_caso is not None
+    non_admin_caso_id = non_admin_caso["id"]
+
+    response = client.get("/api/caso/?user=invalid_value", headers=auth_headers)
+
+    assert response.status_code == 200
+    data = get_success_data(response)
+    assert data is not None
+    items = data["items"]
+    assert isinstance(items, list)
+
+    caso_ids = [caso["id"] for caso in items]
+    assert admin_caso_id in caso_ids
+    assert non_admin_caso_id in caso_ids
+
+
 def test_update_caso_not_found(
     client: FlaskClient, auth_headers: dict[str, str]
 ) -> None:

--- a/web/src/lib/utils/createPaginatedList.svelte.ts
+++ b/web/src/lib/utils/createPaginatedList.svelte.ts
@@ -25,7 +25,16 @@ export function usePaginatedFilters<TFilters extends Record<string, any>>(
 
 	function applyFilters(args: { page?: number } = {}) {
 		const { page: pageNumber = 1 } = args;
-		const params = new URLSearchParams(options.buildParams(filters));
+		const rawParams = options.buildParams(filters);
+
+		const cleanedParams: Record<string, string> = {};
+		for (const [key, value] of Object.entries(rawParams)) {
+			if (value !== '' && value !== undefined && value !== null && value !== 'undefined') {
+				cleanedParams[key] = value;
+			}
+		}
+
+		const params = new URLSearchParams(cleanedParams);
 
 		if (pageNumber > 1) {
 			params.set('page', pageNumber.toString());

--- a/web/src/routes/(dashboard)/casos/+page.svelte
+++ b/web/src/routes/(dashboard)/casos/+page.svelte
@@ -38,18 +38,21 @@
 		search: string;
 		show_inactive: boolean;
 		situacao_deferimento: string;
+		user: string;
 	};
 
 	const { filters, applyFilters, setFilters } = usePaginatedFilters<CasoFilters>({
 		initialFilters: {
 			search: page.url.searchParams.get('search') ?? '',
 			show_inactive: page.url.searchParams.get('show_inactive') === 'true',
-			situacao_deferimento: page.url.searchParams.get('situacao_deferimento') ?? 'todos'
+			situacao_deferimento: page.url.searchParams.get('situacao_deferimento') ?? 'todos',
+			user: page.url.searchParams.get('user') ?? ''
 		},
 		buildParams: (f) => ({
 			search: f.search,
 			show_inactive: f.show_inactive ? 'true' : 'false',
-			situacao_deferimento: f.situacao_deferimento
+			situacao_deferimento: f.situacao_deferimento,
+			user: f.user
 		})
 	});
 
@@ -128,6 +131,7 @@
 							bind:value={filters.situacao_deferimento}
 							name="situacao_deferimento"
 							type="single"
+							onValueChange={() => applyFilters()}
 						>
 							<Select.Trigger class="w-[200px] data-[placeholder]:text-foreground">
 								{situacaoFilterOptions.find(
@@ -141,10 +145,22 @@
 							</Select.Content>
 						</Select.Root>
 					</div>
-					<label class="flex cursor-pointer items-center gap-2">
-						<Checkbox bind:checked={filters.show_inactive} />
-						<span class="text-sm">Incluir inativos</span>
-					</label>
+					<div class="flex items-center gap-4">
+						<label class="flex cursor-pointer items-center gap-2">
+							<Checkbox
+								checked={filters.user === 'me'}
+								onCheckedChange={(checked) => {
+									setFilters({ user: checked ? 'me' : '' });
+									applyFilters();
+								}}
+							/>
+							<span class="text-sm">Apenas meus casos</span>
+						</label>
+						<label class="flex cursor-pointer items-center gap-2">
+							<Checkbox bind:checked={filters.show_inactive} onCheckedChange={() => applyFilters()} />
+							<span class="text-sm">Incluir inativos</span>
+						</label>
+					</div>
 				</div>
 			</div>
 

--- a/web/src/routes/(dashboard)/plantao/atendidos-assistidos/+page.svelte
+++ b/web/src/routes/(dashboard)/plantao/atendidos-assistidos/+page.svelte
@@ -10,6 +10,7 @@
 	import Input from '$lib/components/ui/input/input.svelte';
 	import { page } from '$app/state';
 	import * as Select from '$lib/components/ui/select';
+	import Checkbox from '$lib/components/ui/checkbox/checkbox.svelte';
 	import { usePaginatedFilters } from '$lib';
 
 	let { data }: PageProps = $props();
@@ -73,7 +74,7 @@
 							debounceMs={500}
 							placeholder="Buscar atendido..."
 						/>
-						<Select.Root bind:value={filters.tipo_busca} name="tipo_busca" type="single">
+						<Select.Root bind:value={filters.tipo_busca} name="tipo_busca" type="single" onValueChange={() => applyFilters()}>
 							<Select.Trigger class="w-full data-[placeholder]:text-foreground">
 								{tipoBuscaFilterOptions.find((option) => option.value === filters.tipo_busca)
 									?.label}
@@ -85,6 +86,10 @@
 							</Select.Content>
 						</Select.Root>
 					</div>
+					<label class="flex cursor-pointer items-center gap-2">
+						<Checkbox bind:checked={filters.show_inactive} onCheckedChange={() => applyFilters()}/>
+						<span class="text-sm">Incluir inativos</span>
+					</label>
 				</div>
 			</div>
 

--- a/web/src/routes/(dashboard)/plantao/orientacoes-juridicas/+page.svelte
+++ b/web/src/routes/(dashboard)/plantao/orientacoes-juridicas/+page.svelte
@@ -78,7 +78,7 @@
 							debounceMs={500}
 							placeholder="Buscar orientação..."
 						/>
-						<Select.Root bind:value={filters.area} name="area" type="single">
+						<Select.Root bind:value={filters.area} name="area" type="single" onValueChange={() => applyFilters()}>
 							<Select.Trigger class="w-[200px] data-[placeholder]:text-foreground">
 								{areaFilterOptions.find((option) => option.value === filters.area)?.label}
 							</Select.Trigger>
@@ -90,7 +90,7 @@
 						</Select.Root>
 					</div>
 					<label class="flex cursor-pointer items-center gap-2">
-						<Checkbox bind:checked={filters.show_inactive} />
+						<Checkbox bind:checked={filters.show_inactive} onCheckedChange={() => applyFilters()} />
 						<span class="text-sm">Incluir inativos</span>
 					</label>
 				</div>

--- a/web/src/routes/(dashboard)/usuarios/+page.svelte
+++ b/web/src/routes/(dashboard)/usuarios/+page.svelte
@@ -58,7 +58,7 @@
 								debounceMs={500}
 								placeholder="Buscar usuários..."
 							/>
-							<Select.Root bind:value={filters.funcao} name="funcao" type="single">
+							<Select.Root bind:value={filters.funcao} name="funcao" type="single" onValueChange={() => applyFilters()}>
 								<Select.Trigger class="w-[180px] data-[placeholder]:text-foreground">
 									{roleFilterOptions.find((option) => option.value === filters.funcao)?.label}
 								</Select.Trigger>
@@ -70,7 +70,7 @@
 							</Select.Root>
 						</div>
 						<label class="flex cursor-pointer items-center gap-2">
-							<Checkbox bind:checked={filters.show_inactive} />
+							<Checkbox bind:checked={filters.show_inactive} onCheckedChange={() => applyFilters()} />
 							<span class="text-sm">Incluir inativos</span>
 						</label>
 					</div>


### PR DESCRIPTION
Adiciona filtro de usuário na busca de casos                                                                     
                                                                                                                   
  Esta PR adiciona a capacidade de filtrar casos por usuário (usuário responsável) na funcionalidade de busca.     
                                                                                                                   
  Alterações                                                                                                       
                                                                                                                   
  Backend:
  - Adicionado parâmetro de query user ao endpoint de busca de casos
    - user=me - filtra pelo usuário autenticado atual
    - user=<id> - filtra por ID de usuário específico
    - Valores inválidos são ignorados (retorna todos os casos)
  - Atualizado CasoService.search() para suportar filtragem por id_usuario_responsavel

  Frontend:
  - Atualizada página de casos para incluir filtro de usuário na busca (atualmente estamos apenas implementando interface para o "user=me")
  - Ajusta todas as paginas de busca para corretamente aplicarem os filtros de busca
  usuários)